### PR TITLE
Add a version number to the opam file for opam pin --dev to take it automatically

### DIFF
--- a/opam
+++ b/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "14.0.0~dev"
 synopsis: """Unicode character properties for OCaml"""
 maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 authors: ["The uucp programmers"]


### PR DESCRIPTION
Without it, opam cannot know which version it is and will choose the latest version available in opam-repository as a default (which makes it impossible to install both uucp dev and uunf dev after https://github.com/dbuenzli/uunf/commit/547774dbdd0a8a2dc8588fb6e17fe4881baf62a3)